### PR TITLE
add pipeable operators to Tree-shaking resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ This means that the unused export `bar` will not be included into the final bund
 
 - ["Building an Angular Application for Production"](http://blog.mgechev.com/2016/06/26/tree-shaking-angular2-production-build-rollup-javascript/)
 - ["2.5X Smaller Angular Applications with Google Closure Compiler"](http://blog.mgechev.com/2016/07/21/even-smaller-angular2-applications-closure-tree-shaking/)
+- ["Using pipeable operators in RxJS"](https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md)
 
 ### Ahead-of-Time (AoT) Compilation
 


### PR DESCRIPTION
Since RxJS 5.5, we can use pipeable operators to reduce the bundle size.