### PR TITLE
Replace Mobile Toolkit with Angular Service Worker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ The application shell is the minimum user interface that we show to the users in
 
 **Tooling**
 
-- [Angular Mobile Toolkit](https://github.com/angular/mobile-toolkit) - aims to automate the process of managing Service Workers. It also contains Service Worker for caching static assets, and one for [generating application shell](https://developers.google.com/web/updates/2015/11/app-shell?hl=en).
+- [Angular Service Worker](https://angular.io/guide/service-worker-intro) - aims to automate the process of managing Service Workers. It also contains Service Worker for caching static assets, and one for [generating application shell](https://developers.google.com/web/updates/2015/11/app-shell?hl=en).
 - [Angular Universal](https://github.com/angular/angular/tree/master/packages/platform-server) - Universal (isomorphic) JavaScript support for Angular.
 
 **Resources**
@@ -226,7 +226,7 @@ We can think of the Service Worker as an HTTP proxy which is located in the brow
 
 **Tooling**
 
-- [Angular Mobile Toolkit](https://github.com/angular/mobile-toolkit) - aims to automate the process of managing Service Workers. It also contains Service Worker for caching static assets, and one for [generating application shell](https://developers.google.com/web/updates/2015/11/app-shell?hl=en).
+- [Angular Service Worker](https://angular.io/guide/service-worker-intro) - aims to automate the process of managing Service Workers. It also contains Service Worker for caching static assets, and one for [generating application shell](https://developers.google.com/web/updates/2015/11/app-shell?hl=en).
 - [Offline Plugin for Webpack](https://github.com/NekR/offline-plugin) - Webpack plugin that adds support for Service Worker with a fall-back to AppCache.
 
 **Resources**
@@ -449,4 +449,3 @@ In case you notice something missing, incomplete or incorrect, a pull request wi
 # License
 
 MIT
-


### PR DESCRIPTION
The Mobile Toolkit is deprecated in reason of the Angular Service Worker.