### PR TITLE
fix: Unknown property on Run outside Angular section's demo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ class PointAnimationComponent {
   private _incrementInterval: any;
   private _points: number = 0;
 
-  constructor(private _zone: NgZone, private _pipe: DecimalPipe) {}
+  constructor(private _ngZone: NgZone, private _pipe: DecimalPipe) {}
 
   ngOnChanges(changes: any) {
     const change = changes.points;


### PR DESCRIPTION
The [**Run outside Angular section's demo code**](https://github.com/mgechev/angular-performance-checklist#run-outside-angular)  was using a non-existing property: `PointAnimationComponent`, inside its `ngOnChanges` method, was calling an unknown `_ngZone` property from the `this` object.

This PR renames the declared-by-constructor property `private _zone: NgZone`, to `private _ngZone: NgZone`, this way, the former unknown `_ngZone` property, now gets available, and safely callable within the component scope.

closes https://github.com/mgechev/angular-performance-checklist/issues/55