### PR TITLE
fix: Broken link to article of Max Koretskyi about change detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ The `OnPush` change detection strategy allows us to disable the change detection
 **Resources**
 
 - ["Change Detection in Angular"](https://vsavkin.com/change-detection-in-angular-2-4f216b855d4c)
-- ["Everything you need to know about change detection in Angular"](https://blog.angularindepth.com/everything-you-need-to-know-about-change-detection-in-angular-8006c51d206f)
+- ["Everything you need to know about change detection in Angular"](https://indepth.dev/posts/1053/everything-you-need-to-know-about-change-detection-in-angular)
 
 #### Detaching the Change Detector
 


### PR DESCRIPTION
The domain name of article "Everything you need to know about change detection in Angular" has changed from `blog.angularindepth.com` to `indepth.dev`, so the article link should be changed accordingly.